### PR TITLE
Redirect pings to bot's own channel, 2nd attempt

### DIFF
--- a/cmd/bot/main.go
+++ b/cmd/bot/main.go
@@ -21,7 +21,7 @@ func init() {
 }
 
 func main() {
-	log.Printf("Starting titlechange_bot %s", common.Version())
+	log.Println("Starting titlechange_bot", common.Version())
 
 	cfg := config.New()
 	ctx := context.Background()

--- a/cmd/bot/subevent_test.go
+++ b/cmd/bot/subevent_test.go
@@ -7,36 +7,48 @@ func TestPlaceholderReplacement(t *testing.T) {
 		format         string
 		value          string
 		login          string
+		redirect       bool
 		expectedOutput string
 	}{
 		{
 			"NEW GAME 👉 {value} 👉 foo bar baz",
 			"Artifact",
 			"forsen",
+			false,
 			".me NEW GAME 👉 Artifact 👉 foo bar baz",
 		},
 		{
 			"KKool GuitarTime {login} has gone live KKool GuitarTime",
 			"Just Stalling",
 			"forsen",
+			false,
 			".me KKool GuitarTime forsen has gone live KKool GuitarTime",
 		},
 		{
 			"KKool GuitarTime {login} has gone live KKool GuitarTime",
 			"Just Stalling",
 			"{value}",
+			false,
 			".me KKool GuitarTime {value} has gone live KKool GuitarTime",
 		},
 		{
 			"NEW GAME 👉 {value} foo",
 			"this game has {login} in name",
 			"zneix",
+			false,
 			".me NEW GAME 👉 this game has {login} in name foo",
+		},
+		{
+			"NEW GAME 👉 {value} 👉 whykingr ks romeo zulul",
+			"PUBG: BATTLEGROUNDS",
+			"forsen",
+			true,
+			".me [#forsen] NEW GAME 👉 PUBG: BATTLEGROUNDS 👉 whykingr ks romeo zulul",
 		},
 	}
 
 	for _, test := range testCases {
-		if output := createMessagePrefix(test.format, test.value, test.login); output != test.expectedOutput {
+		if output := createMessagePrefix(test.format, test.value, test.login, test.redirect); output != test.expectedOutput {
 			t.Errorf("Expected %q, but resulted in %q", test.expectedOutput, output)
 		}
 	}

--- a/internal/bot/types.go
+++ b/internal/bot/types.go
@@ -141,6 +141,6 @@ func (e SubEventType) String() string {
 	case SubEventTypePartnered:
 		return "partnered"
 	default:
-		return fmt.Sprintf("invalid(%d)", int(e))
+		return fmt.Sprintf("invalid(%d)", e)
 	}
 }

--- a/internal/eventsub/eventsub.go
+++ b/internal/eventsub/eventsub.go
@@ -42,7 +42,7 @@ func (esub *EventSub) handleIncomingNotification(notification *eventSubNotificat
 		var event helix.EventSubChannelUpdateEvent
 		err := json.Unmarshal(notification.Event, &event)
 		if err != nil {
-			log.Printf("[EventSub] Failed to unmarshal notification event: %s, data: %s\n", err, string(notification.Event))
+			log.Printf("[EventSub] Failed to unmarshal notification event: %s, data: %s\n", err, notification.Event)
 			return
 		}
 		if esub.onChannelUpdateEvent != nil {
@@ -54,7 +54,7 @@ func (esub *EventSub) handleIncomingNotification(notification *eventSubNotificat
 		var event helix.EventSubStreamOnlineEvent
 		err := json.Unmarshal(notification.Event, &event)
 		if err != nil {
-			log.Printf("[EventSub] Failed to unmarshal notification event: %s, data: %s\n", err, string(notification.Event))
+			log.Printf("[EventSub] Failed to unmarshal notification event: %s, data: %s\n", err, notification.Event)
 			return
 		}
 		if esub.onStreamOnlineEvent != nil {
@@ -66,7 +66,7 @@ func (esub *EventSub) handleIncomingNotification(notification *eventSubNotificat
 		var event helix.EventSubStreamOfflineEvent
 		err := json.Unmarshal(notification.Event, &event)
 		if err != nil {
-			log.Printf("[EventSub] Failed to unmarshal notification event: %s, data: %s\n", err, string(notification.Event))
+			log.Printf("[EventSub] Failed to unmarshal notification event: %s, data: %s\n", err, notification.Event)
 			return
 		}
 		if esub.onStreamOfflineEvent != nil {


### PR DESCRIPTION
if a channel had EventsOnlyOffline flag set to true, tcb v1 used to send all these messages but in its own channel instead.
first attempt which I wasn't satisfied with and abandoned was made in #6
